### PR TITLE
Saved catalog data to sessionStorage to avoid repeated queries to server

### DIFF
--- a/Node.js Server Workspace/public/javascripts/ADMIN_search.js
+++ b/Node.js Server Workspace/public/javascripts/ADMIN_search.js
@@ -161,25 +161,30 @@ $(document).ready(function()
     and makes a call to displays all items contained. 
     */
     const loadItems = async () => {
-    
-        //Populate CatalogItemsFull with data from the SQL server: 'sprint2cs341', database: 'sprint2', table: 'products'
+        //since admin can add and delete items, we want to see up to date data, so we load from the sql server
+
+        //Populate CatalogItemsFull with data from the SQL server
         //only do so if the variable is empty (the data has not been loaded yet)
-        if (CatalogItemsFull.length == 0){
+        if (CatalogItemsFull.length == 0) {
             console.log("Attempting to access item data with POST");
             $.post({
                 traditional: true,
                 url: '/catalogData',    // url
-                success: function(data, ) {// success callback
+                success: function (data,) {// success callback
                     readServerData(data);
+                    // save items to sessionStorage
+                    sessionStorage.setItem("catalog_items",JSON.stringify(CatalogItemsFull));
                 }
-            }).fail(function(jqxhr, settings, ex) { 
-                alert('Accessing product data failed, ' + ex + "\nLoading static dataset."); 
+            }).fail(function (jqxhr, settings, ex) {
+                alert('Accessing product data failed, ' + ex + "\nLoading static dataset.");
                 loadStaticDataset();
             });
         }
 
         //load maellable list
         CatalogItems = CatalogItemsFull;
+
+        
     };
 
     function loadStaticDataset(){

--- a/Node.js Server Workspace/public/javascripts/STAFF_individual_page.js
+++ b/Node.js Server Workspace/public/javascripts/STAFF_individual_page.js
@@ -8,6 +8,7 @@ $(function()
 
     /* Saves item's id to request array in sessionStorage */
     function RequestItem() {
+        //get url (item id is at end of url after ?)
         let loc = window.location.href;
         let spli = loc.split('?');
         if (sessionStorage.getItem("requested_item_ids"))

--- a/Node.js Server Workspace/public/javascripts/STAFF_requests_page.js
+++ b/Node.js Server Workspace/public/javascripts/STAFF_requests_page.js
@@ -81,25 +81,39 @@ $(function()
     */
     const loadItems = async () => {
        
+        // if items have already been loaded during the session, retrieve them from sessionStorage
+        if (sessionStorage.getItem("catalog_items"))
+        {
+            CatalogItemsFull = JSON.parse(sessionStorage.getItem("catalog_items"));
+            CatalogItems = CatalogItemsFull;
+            // display requests (this code would be called in readServerData if we had queried the sql server)
+            DisplayRequests();
 
-      //Populate CatalogItemsFull with data from the SQL server: 'sprint2cs341', database: 'sprint2', table: 'products'
-      //only do so if the variable is empty (the data has not been loaded yet)
-      if (CatalogItemsFull.length == 0) {
-          console.log("Attempting to access item data with POST");
-          $.post({
-              traditional: true,
-              url: '/catalogData',    // url
-              success: function (data,) {// success callback
-                  readServerData(data);
-              }
-          }).fail(function (jqxhr, settings, ex) {
-              alert('Accessing product data failed, ' + ex + ".");
+        }
+        else 
+        {
+            //Populate CatalogItemsFull with data from the SQL server
+            //only do so if the variable is empty (the data has not been loaded yet)
+            if (CatalogItemsFull.length == 0) {
+                console.log("Attempting to access item data with POST");
+                $.post({
+                    traditional: true,
+                    url: '/catalogData',    // url
+                    success: function (data,) {// success callback
+                        readServerData(data);
+                        // save items to sessionStorage
+                        sessionStorage.setItem("catalog_items",JSON.stringify(CatalogItemsFull));
+                    }
+                }).fail(function (jqxhr, settings, ex) {
+                    alert('Accessing product data failed, ' + ex + "\nLoading static dataset.");
+                    loadStaticDataset();
+                });
+            }
 
-          });
-      }
+            //load maellable list
+            CatalogItems = CatalogItemsFull;
 
-      //load maellable list
-      CatalogItems = CatalogItemsFull;
+        }
   };
   /*
   Copied from STAFF_search.js

--- a/Node.js Server Workspace/public/javascripts/STAFF_search.js
+++ b/Node.js Server Workspace/public/javascripts/STAFF_search.js
@@ -1,4 +1,4 @@
-$(document).ready(function () {
+$(function () {
     //Author Aidan Day Sprint 2 CS 341
     //Structure of search was taken from James Q Quick's JS Search Bar Tutorial
     //https://www.youtube.com/watch?v=wxz5vJ1BWrc
@@ -176,25 +176,42 @@ $(document).ready(function () {
     */
     const loadItems = async () => {
        
+        // if items have already been loaded during the session, retrieve them from sessionStorage
+        if (sessionStorage.getItem("catalog_items"))
+        {
+            CatalogItemsFull = JSON.parse(sessionStorage.getItem("catalog_items"));
+            CatalogItems = CatalogItemsFull;
+            // display items (this code would be called in readServerData if we had queried the sql server)
+            if (init){
+                displayItems(CatalogItems);
+                init = false;
+            }
+        }
+        else 
+        {
+            //Populate CatalogItemsFull with data from the SQL server
+            //only do so if the variable is empty (the data has not been loaded yet)
+            if (CatalogItemsFull.length == 0) {
+                console.log("Attempting to access item data with POST");
+                $.post({
+                    traditional: true,
+                    url: '/catalogData',    // url
+                    success: function (data,) {// success callback
+                        readServerData(data);
+                        // save items to sessionStorage
+                        sessionStorage.setItem("catalog_items",JSON.stringify(CatalogItemsFull));
+                    }
+                }).fail(function (jqxhr, settings, ex) {
+                    alert('Accessing product data failed, ' + ex + "\nLoading static dataset.");
+                    loadStaticDataset();
+                });
+            }
 
-        //Populate CatalogItemsFull with data from the SQL server: 'sprint2cs341', database: 'sprint2', table: 'products'
-        //only do so if the variable is empty (the data has not been loaded yet)
-        if (CatalogItemsFull.length == 0) {
-            console.log("Attempting to access item data with POST");
-            $.post({
-                traditional: true,
-                url: '/catalogData',    // url
-                success: function (data,) {// success callback
-                    readServerData(data);
-                }
-            }).fail(function (jqxhr, settings, ex) {
-                alert('Accessing product data failed, ' + ex + "\nLoading static dataset.");
-                loadStaticDataset();
-            });
+            //load maellable list
+            CatalogItems = CatalogItemsFull;
+
         }
 
-        //load maellable list
-        CatalogItems = CatalogItemsFull;
     };
 
     function loadStaticDataset() {

--- a/Node.js Server Workspace/public/javascripts/populate_individual_page.js
+++ b/Node.js Server Workspace/public/javascripts/populate_individual_page.js
@@ -2,7 +2,7 @@
 //Version: March 21 2021
 // Pulls information on items from database and loads items based on keys
 
-$(document).ready(function () {
+$(function () {
 
     let CatalogItemsFull = [];
     let CatalogItems = [];
@@ -25,25 +25,39 @@ $(document).ready(function () {
     and makes a call to displays all items contained. 
     */
     const loadItems = async () => {
+        // if items have already been loaded during the session, retrieve them from sessionStorage
+        if (sessionStorage.getItem("catalog_items"))
+        {
+            CatalogItemsFull = JSON.parse(sessionStorage.getItem("catalog_items"));
+            CatalogItems = CatalogItemsFull;
+            // populate the page (this code would be called in readServerData if we had queried the sql server)
+            populatePage()
+        }
+        else 
+        {
+            //Populate CatalogItemsFull with data from the SQL server
+            //only do so if the variable is empty (the data has not been loaded yet)
+            if (CatalogItemsFull.length == 0) {
+                console.log("Attempting to access item data with POST");
+                $.post({
+                    traditional: true,
+                    url: '/catalogData',    // url
+                    success: function (data,) {// success callback
+                        readServerData(data);
+                        // save items to sessionStorage
+                        sessionStorage.setItem("catalog_items",JSON.stringify(CatalogItemsFull));
+                    }
+                }).fail(function (jqxhr, settings, ex) {
+                    alert('Accessing product data failed, ' + ex + "\nLoading static dataset.");
+                    loadStaticDataset();
+                });
+            }
 
-        //Populate CatalogItemsFull with data from the SQL server: 'sprint2cs341', database: 'sprint2', table: 'products'
-        //only do so if the variable is empty (the data has not been loaded yet)
-        if (CatalogItemsFull.length == 0) {
-            console.log("Attempting to access item data with POST");
-            $.post({
-                traditional: true,
-                url: '/catalogData',    // url
-                success: function (data,) {// success callback
-                    readServerData(data);
-                }
-            }).fail(function (jqxhr, settings, ex) {
-                alert('Accessing product data failed, ' + ex + "\nLoading static dataset.");
-                loadStaticDataset();
-            });
+            //load maellable list
+            CatalogItems = CatalogItemsFull;
+
         }
 
-        //load maellable list
-        CatalogItems = CatalogItemsFull;
     };
 
     function loadStaticDataset() {

--- a/Node.js Server Workspace/public/javascripts/search.js
+++ b/Node.js Server Workspace/public/javascripts/search.js
@@ -178,24 +178,41 @@ $(document).ready(function () {
     const loadItems = async () => {
        
 
-        //Populate CatalogItemsFull with data from the SQL server: 'sprint2cs341', database: 'sprint2', table: 'products'
-        //only do so if the variable is empty (the data has not been loaded yet)
-        if (CatalogItemsFull.length == 0) {
-            console.log("Attempting to access item data with POST");
-            $.post({
-                traditional: true,
-                url: '/catalogData',    // url
-                success: function (data,) {// success callback
-                    readServerData(data);
-                }
-            }).fail(function (jqxhr, settings, ex) {
-                alert('Accessing product data failed, ' + ex + "\nLoading static dataset.");
-                loadStaticDataset();
-            });
+        // if items have already been loaded during the session, retrieve them from sessionStorage
+        if (sessionStorage.getItem("catalog_items"))
+        {
+            CatalogItemsFull = JSON.parse(sessionStorage.getItem("catalog_items"));
+            CatalogItems = CatalogItemsFull;
+            // display items (this code would be called in readServerData if we had queried the sql server)
+            if (init){
+                displayItems(CatalogItems);
+                init = false;
+            }
         }
+        else 
+        {
+            //Populate CatalogItemsFull with data from the SQL server
+            //only do so if the variable is empty (the data has not been loaded yet)
+            if (CatalogItemsFull.length == 0) {
+                console.log("Attempting to access item data with POST");
+                $.post({
+                    traditional: true,
+                    url: '/catalogData',    // url
+                    success: function (data,) {// success callback
+                        readServerData(data);
+                        // save items to sessionStorage
+                        sessionStorage.setItem("catalog_items",JSON.stringify(CatalogItemsFull));
+                    }
+                }).fail(function (jqxhr, settings, ex) {
+                    alert('Accessing product data failed, ' + ex + "\nLoading static dataset.");
+                    loadStaticDataset();
+                });
+            }
 
-        //load maellable list
-        CatalogItems = CatalogItemsFull;
+            //load maellable list
+            CatalogItems = CatalogItemsFull;
+
+        }
     };
 
     function loadStaticDataset() {
@@ -215,16 +232,14 @@ $(document).ready(function () {
     //and load into CatalogItemsFull
     function readServerData(data) {
         console.log("Attempting to load item data from SQL server");
-        //console.log(data)
         productDataArray = data.productData;
-        console.log(productDataArray);
+        //console.log(productDataArray);
         productImageArray = data.imageData;
-        console.log(productImageArray);
+        //console.log(productImageArray);
         var i;
-        // CatalogItemsFull.length = productDataArray.length - 1;
         console.log("productDataArray Length: " + productDataArray.length);
         console.log("productImageArray Length: " + productImageArray.length);
-        console.log("CatalogItemsFull Length: " + CatalogItemsFull.length);
+        //console.log("CatalogItemsFull Length: " + CatalogItemsFull.length);
         for (i = 0; i < productDataArray.length; i++) {
             prodData = productDataArray[i];
             //console.log("productDataArray[" + i + "]");
@@ -263,7 +278,7 @@ $(document).ready(function () {
                     for(let j = 0; j < productImageArray.length; j++){
                         if (k == productImageArray[j].key_number){
                             img = productImageArray[j].image;
-                            console.log("Found image for " + bn + ": " + img);
+                            //console.log("Found image for " + bn + ": " + img);
                             break;
                         }
                     }
@@ -281,7 +296,7 @@ $(document).ready(function () {
             var productjson = {itemKey:k, name:bn, image:img, category:c};
             CatalogItemsFull[i] = productjson;
         }
-        console.log(CatalogItemsFull);
+        //console.log(CatalogItemsFull);
         console.log("Item loading complete!");
         if (init){
             displayItems(CatalogItems);


### PR DESCRIPTION
- Catalog data will only load once from server then be saved and loaded from sessionStorage
- Admin catalog will always load from server so that admins can see what they just added or deleted
- Commented out some lines in search.js which were logging a lot of info to the console
- Changed some files to use $(function()... instead of the deprecated $(document).ready(function()...